### PR TITLE
Changed type to Array[true][false] affecting 2 rules in tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -34,7 +34,7 @@
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
-    "no-consecutive-blank-lines": true,
+    "no-consecutive-blank-lines": [true],
     "no-console": [
       false
     ],
@@ -43,7 +43,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-inferrable-types": false,
+    "no-inferrable-types": [false],
     "no-internal-module": true,
     "no-require-imports": false,
     "no-shadowed-variable": true,


### PR DESCRIPTION
I am not sure if this is considered an issue. But I will go ahead and make a pull request after fixing this.        
$ tslint Version 5.2.0
$ tsc Version 2.3.2

This is an "issue" in tslint.json file. I downloaded the tslint.json file from this repo.  I am using vscode which does not like it (green squiggly line) when **"no-consecutive-blank-lines": true**, when I hovered over, tooltip: "Incorrect type: expected Array. Green squiggly line goes away when I give an Array type: **"no-consecutive-blank-lines": [true]**
These are the rules which are currently having the same "issue"
**- "no-consecutive-blank-lines": [true]**
**- "no-inferrable-types": [false]** 